### PR TITLE
open resume in new tab instead of same

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                   </button></a
                 >
                 <a
-                  href="https://drive.google.com/file/d/1SuuVZQM6iXdeDFJvE6MBdVaCTXyTGgaG/view?usp=sharing"
+                  href="https://drive.google.com/file/d/1SuuVZQM6iXdeDFJvE6MBdVaCTXyTGgaG/view?usp=sharing" target="_blank"
                   ><button class="btn btn-primary btn-hero">
                     <i class="fas fa-download"></i> Resume
                   </button></a


### PR DESCRIPTION
Description: Resume was opening in same tab, added `target='_blank'` now it will be opened in new tab. Will also resolve the issue with URL forwarding's `Masked` feature for URL 